### PR TITLE
Add PWA manifest and iOS standalone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Maneuver-Beta
+
+This repository contains a browser-based radar simulator. The app can be
+installed as a Progressive Web App (PWA). On iOS, add it to your home screen
+to launch in standalone mode without Safari's UI chrome.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This repository contains a browser-based radar simulator. The app can be
 installed as a Progressive Web App (PWA). On iOS, add it to your home screen
 to launch in standalone mode without Safari's UI chrome.
+
+When viewed on mobile, rotate to landscape orientation for the best experience. The settings drawer includes an **Add to Home** option to quickly install the simulator as a PWA.

--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -563,3 +563,19 @@ body.pwa-standalone #btn-fullscreen {
 /* Optional visual cue when in full-screen */
 :fullscreen #btn-fullscreen svg { transform: rotate(45deg); }
 :-webkit-full-screen #btn-fullscreen svg { transform: rotate(45deg); }
+
+#orientation-warning {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: #000;
+    color: var(--radar-green);
+    z-index: 9999;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-family: "Share Tech Mono", monospace;
+}
+body.portrait #orientation-warning {
+    display: flex;
+}

--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -514,6 +514,10 @@ details[open] > summary.collapsible-summary::before {
 #btn-fullscreen { bottom: 95px; }
 #btn-settings  { bottom: 45px; }
 
+body.pwa-standalone #btn-fullscreen {
+    display: none;
+}
+
 #btn-settings:hover,
 #btn-fullscreen:hover {
     color: var(--radar-green);

--- a/Simulator/css/install.css
+++ b/Simulator/css/install.css
@@ -1,0 +1,36 @@
+/* install.css - Visual cues for PWA installation */
+
+/* Hidden until JS adds the .show class */
+#btnInstall {
+    display: none;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+#btnInstall.show {
+    display: inline-block;
+    opacity: 1;
+    animation: pulse 1s ease-out 2;
+}
+
+@keyframes pulse {
+    0%, 100% { transform: scale(1); }
+    50%      { transform: scale(1.1); }
+}
+
+/* iOS fallback overlay */
+#iosTip {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.75);
+    color: #fff;
+    font-family: sans-serif;
+    z-index: 10000;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 2rem;
+}
+body.no-install-ios #iosTip {
+    display: flex;
+}

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -42,6 +42,7 @@
     <link rel="stylesheet" href="./css/beta.css"/>
 </head>
 <body>
+    <div id="orientation-warning">Rotate device to landscape</div>
 
 <div id="drag-tooltip"></div>
 <div id="order-tooltip"></div>
@@ -378,6 +379,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
         </svg>
     </button>
     <div id="settings-drawer">
+        <button id="btn-install" class="setting-option">Add to Home</button>
         <label class="setting-option">Polar Plot <input type="checkbox" id="toggle-polar-plot" checked></label>
         <label class="setting-option">Track IDs <input type="checkbox" id="toggle-track-ids" checked></label>
     </div>

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -3,8 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="theme-color" content="#000000">
     <title>Maneuver: Simulator</title>
     <link rel="icon" type="image/svg+xml" href="favicons.svg">
+    <link rel="manifest" href="manifest.webmanifest">
     
     <!-- Bootstrap CSS for styling -->
     <link

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -40,9 +40,11 @@
 
     </style> -->
     <link rel="stylesheet" href="./css/beta.css"/>
+    <link rel="stylesheet" href="./css/install.css"/>
 </head>
 <body>
     <div id="orientation-warning">Rotate device to landscape</div>
+    <div id="iosTip">Tap ‘Share’ → ‘Add to Home Screen’ to install.</div>
 
 <div id="drag-tooltip"></div>
 <div id="order-tooltip"></div>
@@ -379,10 +381,11 @@ Questions?  >>  Aheadflank.ai@gmail.com
         </svg>
     </button>
     <div id="settings-drawer">
-        <button id="btn-install" class="setting-option">Add to Home</button>
+        <button id="btnInstall" class="setting-option" hidden>Add to Home</button>
         <label class="setting-option">Polar Plot <input type="checkbox" id="toggle-polar-plot" checked></label>
         <label class="setting-option">Track IDs <input type="checkbox" id="toggle-track-ids" checked></label>
     </div>
+    <script type="module" src="./js/install.js"></script>
     <script src="./js/arena.js"></script>
     <script>
         window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -273,7 +273,6 @@ class Simulator {
         this.btnFullscreen = document.getElementById('btn-fullscreen');
         this.btnSettings = document.getElementById('btn-settings');
         this.settingsDrawer = document.getElementById('settings-drawer');
-        this.btnInstall = document.getElementById('btn-install');
         this.chkPolarPlot = document.getElementById('toggle-polar-plot');
         this.chkTrackIds = document.getElementById('toggle-track-ids');
 
@@ -1806,11 +1805,6 @@ class Simulator {
 }
 
 // --- Application Entry Point ---
-let deferredInstallPrompt = null;
-window.addEventListener('beforeinstallprompt', (e) => {
-    e.preventDefault();
-    deferredInstallPrompt = e;
-});
 
 function enforceLandscape() {
     const warning = document.getElementById('orientation-warning');
@@ -1831,18 +1825,5 @@ document.addEventListener('DOMContentLoaded', () => {
     enforceLandscape();
     window.addEventListener('orientationchange', enforceLandscape);
     window.addEventListener('resize', enforceLandscape);
-    const installBtn = document.getElementById('btn-install');
-    if (installBtn) {
-        installBtn.addEventListener('click', async () => {
-            if (deferredInstallPrompt) {
-                deferredInstallPrompt.prompt();
-                deferredInstallPrompt = null;
-            } else if (navigator.share) {
-                try { await navigator.share({ url: location.href }); } catch (err) {}
-            } else {
-                alert("Use your browser's share menu to add this page to your home screen.");
-            }
-        });
-    }
     new Simulator();
 });

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -1807,5 +1807,8 @@ class Simulator {
 
 // --- Application Entry Point ---
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.navigator.standalone) {
+        document.body.classList.add('pwa-standalone');
+    }
     new Simulator();
 });

--- a/Simulator/js/install.js
+++ b/Simulator/js/install.js
@@ -1,0 +1,55 @@
+// install.js - Add to Home Screen logic for Maneuver PWA
+// This module registers listeners for PWA installation events and
+// exposes an installation button when appropriate.
+
+let deferredPrompt = null; // event saved for triggering later
+
+// Element references
+const installBtn = document.getElementById('btnInstall');
+const iosTip     = document.getElementById('iosTip');
+
+// Platform detection helpers
+const isIos = /iphone|ipad|ipod/i.test(navigator.userAgent);
+const isInStandalone = window.matchMedia('(display-mode: standalone)').matches ||
+                       navigator.standalone === true;
+
+// Hide promotional UI elements
+function hidePromos() {
+    installBtn?.classList.remove('show');
+    iosTip?.remove();
+}
+
+// ----- Lifecycle -----
+window.addEventListener('load', () => {
+    // If the app is already installed, mark body and hide promos
+    if (isInStandalone) {
+        document.body.classList.add('installed');
+        hidePromos();
+    } else if (isIos && iosTip) {
+        // iOS does not support beforeinstallprompt
+        document.body.classList.add('no-install-ios');
+    }
+});
+
+// Intercept default browser mini-infobar
+window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();              // Cancel the automatic banner
+    deferredPrompt = e;              // Stash the event for later
+    installBtn?.classList.add('show'); // Reveal install button
+});
+
+// Handle user-initiated install
+installBtn?.addEventListener('click', async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    console.log('User response to install prompt:', outcome);
+    deferredPrompt = null;
+    installBtn.classList.remove('show');
+});
+
+// Cleanup when installation finishes
+window.addEventListener('appinstalled', () => {
+    document.body.classList.add('installed');
+    hidePromos();
+});

--- a/Simulator/manifest.webmanifest
+++ b/Simulator/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Maneuver Simulator",
+  "short_name": "Maneuver",
+  "description": "Educational radar and collision avoidance simulator",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "favicons.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document PWA install in README
- register a web manifest for the simulator
- add Apple meta tags and theme color to HTML
- hide fullscreen button when launched from iOS home screen
- expose standalone status in JS for styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867fef1a7c0832583a71e501a60d8a5