### PR TITLE
Fix TOS modal stacking & mobile drawer closing

### DIFF
--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -423,7 +423,8 @@ canvas {
     inset: 0;
     background: rgba(0, 0, 0, 0.95);
     color: #0f0;
-    z-index: 9998;
+    /* Display above the orientation warning overlay */
+    z-index: 10000;
     display: none;
     flex-direction: column;
     align-items: center;

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -515,6 +515,19 @@ class Simulator {
                     }, { once: true });
                 }
             });
+
+            // Close the drawer when tapping outside of it on touch devices
+            document.addEventListener('pointerdown', (e) => {
+                if (e.pointerType === 'touch' &&
+                    this.settingsDrawer.classList.contains('open') &&
+                    !this.settingsDrawer.contains(e.target) &&
+                    e.target !== this.btnSettings) {
+                    this.settingsDrawer.classList.remove('open');
+                    this.settingsDrawer.addEventListener('transitionend', () => {
+                        this.settingsDrawer.style.display = 'none';
+                    }, { once: true });
+                }
+            });
         }
         // Fullscreen toggle
         this.btnFullscreen?.addEventListener('click', () => this.toggleFullScreen());


### PR DESCRIPTION
## Summary
- ensure the Terms of Service modal displays above the orientation overlay so the ACCEPT button works
- close the settings drawer when tapping outside of it on touch screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68681886d2b883259b7f5ccfc826ae1d