### PR TITLE
Adjust vector visuals

### DIFF
--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -16,6 +16,7 @@ const CARDINAL_BEARINGS   = [0, 90, 180, 270];
 const DASH_PATTERN_NONCAR = [4, 4];      // dashed
 const DASH_PATTERN_SOLID  = [];          // solid
 const LABEL_OFFSET_PX     = 6;           // gap between ring and label
+const VECTOR_LINE_WIDTH   = 1.4 * 1.2 * 2; // consistent width for all vectors
 
 function solveCPA(own, tgt) {
     const rx = tgt.x - own.x;
@@ -969,7 +970,7 @@ class Simulator {
 
         // --- Range ring labels ---
         ctx.fillStyle = this.radarFaintGreen;
-        ctx.font = `${Math.max(11, radius * 0.038)}px 'IBM Plex Sans Mono', monospace`;
+        ctx.font = `bold ${Math.max(11, radius * 0.038)}px 'IBM Plex Sans Mono', monospace`;
         ctx.textAlign = 'left';
         ctx.textBaseline = 'middle';
         for (let i = 1; i <= 3; i++) {
@@ -1006,7 +1007,17 @@ class Simulator {
     }
 
     drawRangeRings(center, radius) { this.ctx.strokeStyle = this.radarFaintGreen; this.ctx.lineWidth = 2.7; this.ctx.beginPath(); this.ctx.arc(center, center, radius, 0, 2 * Math.PI); this.ctx.stroke(); for (let i = 1; i < 3; i++) { this.ctx.beginPath(); this.ctx.arc(center, center, radius * (i / 3), 0, 2 * Math.PI); this.ctx.stroke(); } }
-    drawRangeLabels(center, radius) { this.ctx.fillStyle = this.radarFaintGreen; this.ctx.font = `${Math.max(11, radius * 0.038)}px 'IBM Plex Sans Mono',monospace`; this.ctx.textAlign = 'left'; this.ctx.textBaseline = 'middle'; for (let i = 1; i <= 3; i++) { const ringRadius = radius * (i / 3); const range = this.maxRange * (i / 3); this.ctx.fillText(range.toFixed(1), center + ringRadius + LABEL_OFFSET_PX, center); } }
+    drawRangeLabels(center, radius) {
+        this.ctx.fillStyle = this.radarFaintGreen;
+        this.ctx.font = `bold ${Math.max(11, radius * 0.038)}px 'IBM Plex Sans Mono',monospace`;
+        this.ctx.textAlign = 'left';
+        this.ctx.textBaseline = 'middle';
+        for (let i = 1; i <= 3; i++) {
+            const ringRadius = radius * (i / 3);
+            const range = this.maxRange * (i / 3);
+            this.ctx.fillText(range.toFixed(1), center + ringRadius + LABEL_OFFSET_PX, center);
+        }
+    }
 
     drawOwnShipIcon(center, radius) {
         this.ctx.strokeStyle = this.radarGreen;
@@ -1022,6 +1033,7 @@ class Simulator {
         const endX = center + vectorDistPixels * Math.cos(courseAngle);
         const endY = center - vectorDistPixels * Math.sin(courseAngle);
         this.ownShip.vectorEndpoint = { x: endX, y: endY };
+        this.ctx.lineWidth = VECTOR_LINE_WIDTH;
         this.ctx.beginPath();
         this.ctx.moveTo(center, center);
         this.ctx.lineTo(endX, endY);
@@ -1040,7 +1052,7 @@ class Simulator {
             this.ownShip.orderedVectorEndpoint = { x: oEndX, y: oEndY };
             this.ctx.save();
             this.ctx.strokeStyle = this.radarDarkOrange;
-            this.ctx.lineWidth = 1.4 * 1.2 * 2;
+            this.ctx.lineWidth = VECTOR_LINE_WIDTH;
             this.ctx.beginPath();
             this.ctx.moveTo(center, center);
             this.ctx.lineTo(oEndX, oEndY);
@@ -1050,7 +1062,7 @@ class Simulator {
             const rect = this.canvas.getBoundingClientRect();
             const tipX = rect.left + (oEndX / this.DPR);
             const tipY = rect.top + (oEndY / this.DPR);
-            const txt = `Crs: ${orderedCourse.toFixed(1)} T\nSpd: ${orderedSpeed.toFixed(1)} kts`;
+            const txt = `Crs: ${this.formatBearing(orderedCourse)} T\nSpd: ${orderedSpeed.toFixed(1)} kts`;
             this.orderTooltip.style.color = this.radarDarkOrange;
             this.orderTooltip.innerText = txt;
             this.orderTooltip.style.display = 'block';
@@ -1068,7 +1080,7 @@ class Simulator {
             const dEndY = center - dragDistPixels * Math.sin(dragAngle);
             this.ctx.save();
             this.ctx.strokeStyle = this.radarWhite;
-            this.ctx.lineWidth = 1.4 * 1.2 * 2;
+            this.ctx.lineWidth = VECTOR_LINE_WIDTH;
             this.ctx.beginPath();
             this.ctx.moveTo(center, center);
             this.ctx.lineTo(dEndX, dEndY);
@@ -1091,6 +1103,7 @@ class Simulator {
         this.ctx.strokeStyle = this.radarGreen;
         this.ctx.lineWidth = 1.8;
         this.ctx.strokeRect(x - targetSize / 2, y - targetSize / 2, targetSize, targetSize);
+        this.ctx.lineWidth = VECTOR_LINE_WIDTH;
         const timeInHours = this.vectorTimeInMinutes / 60;
         const pixelsPerNm = radius / this.maxRange;
         const vectorDistPixels = track.speed * timeInHours * pixelsPerNm;
@@ -1122,7 +1135,7 @@ class Simulator {
         const endY = startY - vectorDistPixels * Math.sin(vectorAngleRad);
         this.ctx.save();
         this.ctx.strokeStyle = this.radarGreen;
-        this.ctx.lineWidth = 1.8;
+        this.ctx.lineWidth = VECTOR_LINE_WIDTH;
         this.ctx.setLineDash([5, 5]);
         this.ctx.beginPath();
         this.ctx.moveTo(startX, startY);
@@ -1195,7 +1208,7 @@ class Simulator {
         this.ctx.textAlign   = 'center';
         this.ctx.textBaseline = 'middle';
         this.ctx.fillText('W', wX, wY);
-        this.ctx.lineWidth = 2;
+        this.ctx.lineWidth = VECTOR_LINE_WIDTH;
         this.ctx.beginPath();
         this.ctx.moveTo(startX, startY);
         this.ctx.lineTo(endX, endY);
@@ -1220,7 +1233,7 @@ class Simulator {
 
             this.ctx.save();
             this.ctx.strokeStyle = this.radarFaintGreen;
-            this.ctx.lineWidth = 1.8;
+            this.ctx.lineWidth = VECTOR_LINE_WIDTH;
             this.ctx.setLineDash([5, 5]);
             this.ctx.beginPath();
             this.ctx.moveTo(center, center);


### PR DESCRIPTION
## Summary
- add `VECTOR_LINE_WIDTH` constant
- make range ring labels bold
- format ordered course tooltip bearings with leading zeros
- standardize all vector drawing widths using `VECTOR_LINE_WIDTH`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68683aa4874c8325985d17fc80643ed0