### PR TITLE
Implement COLREGS maneuver utilities

### DIFF
--- a/src/tests/colregs.test.ts
+++ b/src/tests/colregs.test.ts
@@ -1,0 +1,43 @@
+// Jest tests for ColregsBias utilities
+import { classifyEncounter, getLegalPreferredVelocity } from '../traffic/ColregsBias';
+
+describe('classifyEncounter', () => {
+    test('head-on encounter', () => {
+        expect(classifyEncounter(178)).toBe('headOn');
+    });
+
+    test('crossing starboard encounter', () => {
+        expect(classifyEncounter(45)).toBe('crossingStarboard');
+    });
+
+    test('crossing port encounter', () => {
+        expect(classifyEncounter(315)).toBe('crossingPort');
+    });
+
+    test('overtaking encounter', () => {
+        expect(classifyEncounter(200)).toBe('overtaking');
+    });
+});
+
+describe('getLegalPreferredVelocity', () => {
+    const baseVelocity: [number, number] = [1, 0];
+    const turnRate = Math.PI / 4; // 45 degrees
+
+    test('rotates to starboard during crossing starboard', () => {
+        const v = getLegalPreferredVelocity('crossingStarboard', baseVelocity, turnRate);
+        expect(v[0]).toBeCloseTo(Math.cos(-turnRate));
+        expect(v[1]).toBeCloseTo(Math.sin(-turnRate));
+    });
+
+    test('rotates to starboard during head-on', () => {
+        const v = getLegalPreferredVelocity('headOn', baseVelocity, turnRate);
+        expect(v[0]).toBeCloseTo(Math.cos(-turnRate));
+        expect(v[1]).toBeCloseTo(Math.sin(-turnRate));
+    });
+
+    test('maintains course during crossing port', () => {
+        const v = getLegalPreferredVelocity('crossingPort', baseVelocity, turnRate);
+        expect(v[0]).toBeCloseTo(baseVelocity[0]);
+        expect(v[1]).toBeCloseTo(baseVelocity[1]);
+    });
+});

--- a/src/traffic/ColregsBias.ts
+++ b/src/traffic/ColregsBias.ts
@@ -1,3 +1,79 @@
+/** Possible COLREGS encounter types between two vessels. */
+export type Encounter =
+    | 'headOn'
+    | 'crossingStarboard'
+    | 'crossingPort'
+    | 'overtaking'
+    | 'none';
+
 export class ColregsBias {
     // Placeholder for COLREGS bias logic
+}
+
+/**
+ * Classifies the relative encounter type based on bearing to the target.
+ *
+ * The input bearing is expected to be the target's relative bearing in degrees
+ * where 0 degrees is dead ahead and positive angles are measured clockwise.
+ */
+export function classifyEncounter(bearingDeg: number): Encounter {
+    // Normalize the angle to the range [0, 360).
+    const b = ((bearingDeg % 360) + 360) % 360;
+
+    // Head on: +/-5 degrees around 180.
+    if (b >= 175 && b <= 185) {
+        return 'headOn';
+    }
+
+    // Overtaking: target is generally astern.
+    if (b >= 112.5 && b <= 247.5) {
+        return 'overtaking';
+    }
+
+    // Crossing on the starboard bow.
+    if (b < 112.5) {
+        return 'crossingStarboard';
+    }
+
+    // Crossing on the port bow.
+    if (b > 247.5) {
+        return 'crossingPort';
+    }
+
+    return 'none';
+}
+
+/** Rotates a 2D vector by the provided angle in radians. */
+function rotate(vec: [number, number], angleRad: number): [number, number] {
+    const [x, y] = vec;
+    const cos = Math.cos(angleRad);
+    const sin = Math.sin(angleRad);
+    return [x * cos - y * sin, x * sin + y * cos];
+}
+
+/**
+ * Returns a COLREGS compliant preferred velocity based on the encounter type.
+ */
+export function getLegalPreferredVelocity(
+    encounter: Encounter,
+    currentVelocity: [number, number],
+    turnRateRadPerSec: number
+): [number, number] {
+    switch (encounter) {
+        case 'headOn':
+        case 'crossingStarboard':
+            // Give-way vessel: turn to starboard.
+            return rotate(currentVelocity, -turnRateRadPerSec);
+
+        case 'crossingPort':
+            // Stand-on vessel: maintain course and speed.
+            return currentVelocity;
+
+        case 'overtaking':
+            // Slow down slightly to allow the vessel ahead to clear.
+            return [currentVelocity[0] * 0.9, currentVelocity[1] * 0.9];
+
+        default:
+            return currentVelocity;
+    }
 }

--- a/src/traffic/TrafficSim.ts
+++ b/src/traffic/TrafficSim.ts
@@ -1,3 +1,138 @@
-export class TrafficSim {
-    // Placeholder for traffic simulation
+import { OrcaWrapper } from './OrcaWrapper';
+import {
+    ColregsBias,
+    classifyEncounter,
+    Encounter,
+    mergeEncounters,
+} from './ColregsBias';
+
+export interface Track {
+    id: string;
+    pos: [number, number];
+    vel: [number, number];
+    waypoints: [number, number][];
+    encounter?: Encounter;
 }
+
+export interface TrafficSimArgs {
+    timeStep: number;
+    timeHorizon: number;
+    neighborDist: number;
+    radius: number;
+    maxSpeed: number;
+    turnRateRadPerSec: number;
+}
+
+export class TrafficSim {
+    private wrapper: OrcaWrapper;
+    private tracks: Map<string, Track> = new Map();
+    private bias: ColregsBias;
+
+    constructor(args: TrafficSimArgs) {
+        this.wrapper = new OrcaWrapper(
+            args.timeStep,
+            args.timeHorizon,
+            args.neighborDist,
+            args.radius,
+            args.maxSpeed
+        );
+        this.bias = new ColregsBias(args.turnRateRadPerSec);
+    }
+
+    /** Adds a new vessel to the simulation. */
+    addTrack(
+        id: string,
+        startPos: [number, number],
+        waypoints: [number, number][],
+        speedMps: number
+    ): void {
+        const wp = waypoints[0] || startPos;
+        const dir = this.normalize([wp[0] - startPos[0], wp[1] - startPos[1]]);
+        const vel: [number, number] = [dir[0] * speedMps, dir[1] * speedMps];
+
+        this.wrapper.addAgent(id, startPos, vel);
+        this.tracks.set(id, { id, pos: [...startPos] as [number, number], vel, waypoints });
+    }
+
+    /** Main simulation update step. */
+    tick(): void {
+        const trackList = Array.from(this.tracks.values());
+
+        // Reset encounters
+        for (const t of trackList) {
+            t.encounter = 'none';
+        }
+
+        // Classify encounters pairwise
+        for (let i = 0; i < trackList.length; i++) {
+            for (let j = i + 1; j < trackList.length; j++) {
+                const a = trackList[i];
+                const b = trackList[j];
+
+                // Relative bearing from a to b
+                const relAB: [number, number] = [b.pos[0] - a.pos[0], b.pos[1] - a.pos[1]];
+                const bearingAB = this.bearingRelativeTo(relAB, a.vel);
+                a.encounter = mergeEncounters(a.encounter || 'none', classifyEncounter(bearingAB));
+
+                // Relative bearing from b to a
+                const relBA: [number, number] = [-relAB[0], -relAB[1]];
+                const bearingBA = this.bearingRelativeTo(relBA, b.vel);
+                b.encounter = mergeEncounters(b.encounter || 'none', classifyEncounter(bearingBA));
+            }
+        }
+
+        // Set preferred velocities
+        for (const t of trackList) {
+            // Navigate toward the next waypoint at current speed
+            let desired = t.vel;
+            const speed = Math.hypot(t.vel[0], t.vel[1]);
+            const wp = t.waypoints[0];
+            if (wp) {
+                const dir = this.normalize([wp[0] - t.pos[0], wp[1] - t.pos[1]]);
+                desired = [dir[0] * speed, dir[1] * speed];
+
+                // Waypoint reached?
+                if (Math.hypot(wp[0] - t.pos[0], wp[1] - t.pos[1]) < speed * 1.5) {
+                    t.waypoints.shift();
+                }
+            }
+
+            const pref = this.bias.apply(t.encounter || 'none', desired);
+            this.wrapper.setPreferredVelocity(t.id, pref);
+        }
+
+        // Step the ORCA simulator
+        this.wrapper.step();
+
+        // Update tracks from wrapper
+        for (const t of trackList) {
+            t.vel = this.wrapper.getVelocity(t.id);
+            t.pos = this.wrapper.getPosition(t.id);
+        }
+    }
+
+    /** Returns a simple snapshot of all track states. */
+    getSnapshot(): { id: string; pos: [number, number]; vel: [number, number] }[] {
+        const result = [] as { id: string; pos: [number, number]; vel: [number, number] }[];
+        for (const t of this.tracks.values()) {
+            result.push({ id: t.id, pos: [...t.pos] as [number, number], vel: [...t.vel] as [number, number] });
+        }
+        return result;
+    }
+
+    private normalize(v: [number, number]): [number, number] {
+        const len = Math.hypot(v[0], v[1]);
+        if (len === 0) {
+            return [0, 0];
+        }
+        return [v[0] / len, v[1] / len];
+    }
+
+    private bearingRelativeTo(target: [number, number], referenceVel: [number, number]): number {
+        const bearing = Math.atan2(target[1], target[0]);
+        const heading = Math.atan2(referenceVel[1], referenceVel[0]);
+        const diff = bearing - heading;
+        return (diff * 180) / Math.PI;
+    }
+}
+

--- a/tests/colregs.test.ts
+++ b/tests/colregs.test.ts
@@ -1,6 +1,13 @@
-import { ColregsBias } from '../src/traffic/ColregsBias';
+import { ColregsBias, classifyEncounter } from '../src/traffic/ColregsBias';
 
 test('ColregsBias should be instantiable', () => {
-    const bias = new ColregsBias();
+    const bias = new ColregsBias(0.1);
     expect(bias).toBeInstanceOf(ColregsBias);
+});
+
+test('classifyEncounter correctly categorizes bearings', () => {
+    expect(classifyEncounter(0)).toBe('headOn');
+    expect(classifyEncounter(10)).toBe('crossingStarboard');
+    expect(classifyEncounter(200)).toBe('overtaking');
+    expect(classifyEncounter(300)).toBe('crossingPort');
 });


### PR DESCRIPTION
## Summary
- add encounter type definitions
- implement encounter classification logic
- implement preferred velocity calculation respecting COLREGS rules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da303293c8325906ca27da7ebbb8d