### PR TITLE
Add comprehensive COLREGS tests

### DIFF
--- a/src/tests/colregs.test.ts
+++ b/src/tests/colregs.test.ts
@@ -1,0 +1,43 @@
+// Jest tests for ColregsBias utilities
+import { classifyEncounter, getLegalPreferredVelocity } from '../traffic/ColregsBias';
+
+describe('classifyEncounter', () => {
+    test('head-on encounter', () => {
+        expect(classifyEncounter(178)).toBe('headOn');
+    });
+
+    test('crossing starboard encounter', () => {
+        expect(classifyEncounter(45)).toBe('crossingStarboard');
+    });
+
+    test('crossing port encounter', () => {
+        expect(classifyEncounter(315)).toBe('crossingPort');
+    });
+
+    test('overtaking encounter', () => {
+        expect(classifyEncounter(200)).toBe('overtaking');
+    });
+});
+
+describe('getLegalPreferredVelocity', () => {
+    const baseVelocity: [number, number] = [1, 0];
+    const turnRate = Math.PI / 4; // 45 degrees
+
+    test('rotates to starboard during crossing starboard', () => {
+        const v = getLegalPreferredVelocity('crossingStarboard', baseVelocity, turnRate);
+        expect(v[0]).toBeCloseTo(Math.cos(-turnRate));
+        expect(v[1]).toBeCloseTo(Math.sin(-turnRate));
+    });
+
+    test('rotates to starboard during head-on', () => {
+        const v = getLegalPreferredVelocity('headOn', baseVelocity, turnRate);
+        expect(v[0]).toBeCloseTo(Math.cos(-turnRate));
+        expect(v[1]).toBeCloseTo(Math.sin(-turnRate));
+    });
+
+    test('maintains course during crossing port', () => {
+        const v = getLegalPreferredVelocity('crossingPort', baseVelocity, turnRate);
+        expect(v[0]).toBeCloseTo(baseVelocity[0]);
+        expect(v[1]).toBeCloseTo(baseVelocity[1]);
+    });
+});

--- a/tests/colregs.test.ts
+++ b/tests/colregs.test.ts
@@ -1,6 +1,13 @@
-import { ColregsBias } from '../src/traffic/ColregsBias';
+import { ColregsBias, classifyEncounter } from '../src/traffic/ColregsBias';
 
 test('ColregsBias should be instantiable', () => {
-    const bias = new ColregsBias();
+    const bias = new ColregsBias(0.1);
     expect(bias).toBeInstanceOf(ColregsBias);
+});
+
+test('classifyEncounter correctly categorizes bearings', () => {
+    expect(classifyEncounter(0)).toBe('headOn');
+    expect(classifyEncounter(10)).toBe('crossingStarboard');
+    expect(classifyEncounter(200)).toBe('overtaking');
+    expect(classifyEncounter(300)).toBe('crossingPort');
 });


### PR DESCRIPTION
## Summary
- add Jest tests for `classifyEncounter` and `getLegalPreferredVelocity`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da50c2a5c83259dd5c86408d38902