### PR TITLE
Extend TrafficSim horizon

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,20 @@ All distances and positions are measured in nautical miles (nm). Speeds within
 the simulation are stored as nautical miles per second (nm/s). When adding a new
 track, any provided speed in metres per second is converted to nm/s before being
 applied.
+
+## Example
+
+```ts
+import { TrafficSim } from './src/traffic/TrafficSim';
+
+const sim = new TrafficSim({
+    timeStep: 1,
+    // 90 s horizon ensures contacts at the bow CPA distance are detected for
+    // vessels moving around 10 m/s (~20 kts).
+    timeHorizon: 90,
+    neighborDist: 10,
+    radius: 0.1,
+    maxSpeed: 10,
+    turnRateRadPerSec: 0.1,
+});
+```

--- a/src/tests/cpa.test.ts
+++ b/src/tests/cpa.test.ts
@@ -39,7 +39,7 @@ describe('computeCPA', () => {
     test('returns large time when velocities are parallel', () => {
         const sim = new TrafficSim({
             timeStep: 1,
-            timeHorizon: 5,
+            timeHorizon: 90,
             neighborDist: 10,
             radius: 0.1,
             maxSpeed: 10,
@@ -55,7 +55,7 @@ describe('computeCPA', () => {
     test('computes symmetric approach distance', () => {
         const sim = new TrafficSim({
             timeStep: 1,
-            timeHorizon: 5,
+            timeHorizon: 90,
             neighborDist: 10,
             radius: 0.1,
             maxSpeed: 10,
@@ -70,7 +70,7 @@ describe('computeCPA', () => {
     test('distant CPA yields smaller course correction', () => {
         const args = {
             timeStep: 1,
-            timeHorizon: 5,
+            timeHorizon: 90,
             neighborDist: 10,
             radius: 0.1,
             maxSpeed: 10,

--- a/src/traffic/TrafficSim.ts
+++ b/src/traffic/TrafficSim.ts
@@ -16,6 +16,12 @@ export interface Track {
 
 export interface TrafficSimArgs {
     timeStep: number;
+    /**
+     * Prediction horizon for the ORCA solver in seconds. It should be long
+     * enough that a vessel travelling at typical speeds (~10 m/s or 20 kts)
+     * covers at least the bow CPA distance. This works out to roughly
+     * 60–120 seconds for the default CPA values.
+     */
     timeHorizon: number;
     neighborDist: number;
     radius: number;
@@ -31,7 +37,10 @@ export class TrafficSim {
     private bias: ColregsBias;
 
     // Minimum allowed CPA distances in simulation units (nautical miles).
-    // 1000 yards ~ 0.5 nm, 500 yards ~ 0.25 nm.
+    // 1000 yards ~ 0.5 nm, 500 yards ~ 0.25 nm. The `timeHorizon` value passed
+    // to the constructor should span enough time for a vessel moving at
+    // ordinary speeds to cover at least CPA_BOW_MIN. At around 10 m/s this
+    // equates to roughly one to two minutes.
     private static readonly CPA_BOW_MIN = 1000 / 1852;
     private static readonly CPA_STERN_MIN = 500 / 1852;
 


### PR DESCRIPTION
## Summary
- document rationale for ORCA horizon in `TrafficSim`
- extend horizon in README example
- use 90s horizon in CPA tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db2b8089083258e17f83223d6a03f