### PR TITLE
Export computeCPA as util

### DIFF
--- a/src/tests/cpa.test.ts
+++ b/src/tests/cpa.test.ts
@@ -1,4 +1,4 @@
-import { TrafficSim } from '../traffic/TrafficSim';
+import { TrafficSim, computeCPA } from '../traffic/TrafficSim';
 
 // Simple stub for the ORCA wrapper used by tests. It exposes only the minimal
 // API required by `TrafficSim` and stores preferred velocities so the tests can
@@ -48,7 +48,7 @@ describe('computeCPA', () => {
 
         const a: any = { id: 'a', pos: [0, 0], vel: [1, 0], waypoints: [] };
         const b: any = { id: 'b', pos: [1, 0], vel: [1, 0], waypoints: [] };
-        const cpa = (sim as any).computeCPA(a, b);
+        const cpa = computeCPA(a, b);
         expect(cpa.time).toBeGreaterThan(1e8);
     });
 
@@ -63,7 +63,7 @@ describe('computeCPA', () => {
         });
         const a: any = { id: 'a', pos: [0, 0], vel: [1, 0], waypoints: [] };
         const b: any = { id: 'b', pos: [1, 0], vel: [-1, 0], waypoints: [] };
-        const cpa = (sim as any).computeCPA(a, b);
+        const cpa = computeCPA(a, b);
         expect(cpa.dist).toBeCloseTo(0, 5);
     });
 

--- a/src/traffic/TrafficSim.ts
+++ b/src/traffic/TrafficSim.ts
@@ -118,7 +118,7 @@ export class TrafficSim {
             let push: [number, number] = [0, 0];
             for (const other of trackList) {
                 if (other === t) continue;
-                const { time: tcpa, dist: dcpa } = this.computeCPA(t, other);
+                const { time: tcpa, dist: dcpa } = computeCPA(t, other);
                 if (tcpa < 0) continue;
                 const rel: [number, number] = [other.pos[0] - t.pos[0], other.pos[1] - t.pos[1]];
                 const bearing = this.bearingRelativeTo(rel, t.vel);
@@ -182,24 +182,25 @@ export class TrafficSim {
         return (diff * 180) / Math.PI;
     }
 
-    /**
-     * Computes time and distance of closest point of approach between two tracks.
-     */
-    private computeCPA(
-        a: Track,
-        b: Track
-    ): { time: number; dist: number } {
-        const rx = b.pos[0] - a.pos[0];
-        const ry = b.pos[1] - a.pos[1];
-        const vx = b.vel[0] - a.vel[0];
-        const vy = b.vel[1] - a.vel[1];
+}
 
-        const v2 = vx * vx + vy * vy;
-        const t = v2 < 1e-6 ? 1e9 : -((rx * vx + ry * vy) / v2);
-        const xCPA = rx + vx * t;
-        const yCPA = ry + vy * t;
-        const d = Math.hypot(xCPA, yCPA);
-        return { time: t, dist: d };
-    }
+/**
+ * Computes time and distance of closest point of approach between two tracks.
+ */
+export function computeCPA(
+    a: Track,
+    b: Track
+): { time: number; dist: number } {
+    const rx = b.pos[0] - a.pos[0];
+    const ry = b.pos[1] - a.pos[1];
+    const vx = b.vel[0] - a.vel[0];
+    const vy = b.vel[1] - a.vel[1];
+
+    const v2 = vx * vx + vy * vy;
+    const t = v2 < 1e-6 ? 1e9 : -((rx * vx + ry * vy) / v2);
+    const xCPA = rx + vx * t;
+    const yCPA = ry + vy * t;
+    const d = Math.hypot(xCPA, yCPA);
+    return { time: t, dist: d };
 }
 


### PR DESCRIPTION
## Summary
- expose `computeCPA` as a named function
- use the exported function inside `TrafficSim`
- update CPA tests to import the utility directly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db4a19bb48325bf55ba91be2bd879