### PR TITLE
Integrate ShipDynamics model

### DIFF
--- a/tests/ship-dynamics.test.ts
+++ b/tests/ship-dynamics.test.ts
@@ -1,0 +1,19 @@
+import { ShipDynamics } from '../Simulator/js/ship-dynamics.js';
+
+const KT_TO_MPS = 0.514444;
+
+test('acceleration limited to 0.07 m/s^2', () => {
+    const ship = new ShipDynamics();
+    ship.v = 10; // kts
+    ship.update(1, 0, 20); // command 20 kts
+    const dv = ship.v * KT_TO_MPS - 10 * KT_TO_MPS;
+    expect(dv).toBeCloseTo(0.07, 3);
+});
+
+test('turn rate follows Nomoto dynamics', () => {
+    const ship = new ShipDynamics();
+    ship.v = 20;
+    ship.update(1, 35, 20);
+    expect(ship.r).toBeCloseTo(0.0039, 3);
+    expect(ship.psi).toBeCloseTo(0.0039, 3);
+});


### PR DESCRIPTION
## Summary
- integrate ShipDynamics into `TrafficSim`
- propagate ORCA velocities through ShipDynamics for realistic motion
- expose ShipDynamics per track
- add regression tests for acceleration and turn rate limits

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e2a87bc048325a0f8b6ee5c25c459