### PR TITLE
Fix ORCA wrapper initialization bug

### DIFF
--- a/src/traffic/TrafficSim.ts
+++ b/src/traffic/TrafficSim.ts
@@ -90,6 +90,9 @@ export class TrafficSim {
     private tracks: Map<string, Track> = new Map();
     private bias: ColregsBias;
     private dt: number;
+    private index: GridIndex;
+    private neighborDist: number;
+    private enableCpaPush: boolean;
 
     // Minimum allowed CPA distances in simulation units (nautical miles).
     // 1000 yards ~ 0.5 nm, 500 yards ~ 0.25 nm. The `timeHorizon` value passed
@@ -114,6 +117,9 @@ export class TrafficSim {
         );
         this.bias = new ColregsBias(args.turnRateRadPerSec);
         this.dt = args.timeStep;
+        this.neighborDist = args.neighborDist;
+        this.index = new GridIndex(this.neighborDist);
+        this.enableCpaPush = args.enableCpaPush !== false;
     }
 
     /** Adds a new vessel to the simulation. */
@@ -192,35 +198,37 @@ export class TrafficSim {
 
             // Apply CPA constraints relative to nearby tracks
             let push: [number, number] = [0, 0];
-            for (const other of this.index.query(t.pos)) {
-                if (other === t) continue;
-                const distNow = Math.hypot(
-                    other.pos[0] - t.pos[0],
-                    other.pos[1] - t.pos[1]
-                );
-                if (distNow > this.neighborDist) continue;
-                const { time: tcpa, dist: dcpa } = computeCPA(t, other);
-                if (tcpa < 0) continue;
-                const rel: [number, number] = [other.pos[0] - t.pos[0], other.pos[1] - t.pos[1]];
-                const bearing = this.bearingRelativeTo(rel, t.vel);
-                const enc = classifyEncounter(bearing);
-                const minDist =
-                    enc === 'headOn' || enc === 'crossingStarboard' || enc === 'crossingPort'
-                        ? TrafficSim.CPA_BOW_MIN
-                        : TrafficSim.CPA_STERN_MIN;
-                if (dcpa < minDist) {
-                    const dir = this.normalize([-rel[0], -rel[1]]);
-                    let factor = (minDist - dcpa) / minDist;
-                    // Give closer CPA threats higher priority by scaling with
-                    // the inverse time to CPA. Clamp the scale to avoid
-                    // excessive corrections for very small tcpa values.
-                    factor *= 1 / Math.max(tcpa, 1);
-                    push = [
-                        push[0] +
-                            dir[0] * factor * speed * TrafficSim.AVOIDANCE_GAIN,
-                        push[1] +
-                            dir[1] * factor * speed * TrafficSim.AVOIDANCE_GAIN,
-                    ];
+            if (this.enableCpaPush) {
+                for (const other of this.index.query(t.pos)) {
+                    if (other === t) continue;
+                    const distNow = Math.hypot(
+                        other.pos[0] - t.pos[0],
+                        other.pos[1] - t.pos[1]
+                    );
+                    if (distNow > this.neighborDist) continue;
+                    const { time: tcpa, dist: dcpa } = computeCPA(t, other);
+                    if (tcpa < 0) continue;
+                    const rel: [number, number] = [other.pos[0] - t.pos[0], other.pos[1] - t.pos[1]];
+                    const bearing = this.bearingRelativeTo(rel, t.vel);
+                    const enc = classifyEncounter(bearing);
+                    const minDist =
+                        enc === 'headOn' || enc === 'crossingStarboard' || enc === 'crossingPort'
+                            ? TrafficSim.CPA_BOW_MIN
+                            : TrafficSim.CPA_STERN_MIN;
+                    if (dcpa < minDist) {
+                        const dir = this.normalize([-rel[0], -rel[1]]);
+                        let factor = (minDist - dcpa) / minDist;
+                        // Give closer CPA threats higher priority by scaling with
+                        // the inverse time to CPA. Clamp the scale to avoid
+                        // excessive corrections for very small tcpa values.
+                        factor *= 1 / Math.max(tcpa, 1);
+                        push = [
+                            push[0] +
+                                dir[0] * factor * speed * TrafficSim.AVOIDANCE_GAIN,
+                            push[1] +
+                                dir[1] * factor * speed * TrafficSim.AVOIDANCE_GAIN,
+                        ];
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- store neighbor distance and grid index in `TrafficSim`
- allow disabling CPA push logic via `enableCpaPush`

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686e3f91cf3c8325a57517c36df7c537