### PR TITLE
Fix CPA calculation with Infinity sentinel

### DIFF
--- a/src/tests/cpa.test.ts
+++ b/src/tests/cpa.test.ts
@@ -49,7 +49,7 @@ describe('computeCPA', () => {
         const a: any = { id: 'a', pos: [0, 0], vel: [1, 0], waypoints: [] };
         const b: any = { id: 'b', pos: [1, 0], vel: [1, 0], waypoints: [] };
         const cpa = computeCPA(a, b);
-        expect(cpa.time).toBeGreaterThan(1e8);
+        expect(cpa.time).toBe(Infinity);
     });
 
     test('computes symmetric approach distance', () => {

--- a/src/traffic/TrafficSim.ts
+++ b/src/traffic/TrafficSim.ts
@@ -308,7 +308,14 @@ export function computeCPA(
     const vy = b.vel[1] - a.vel[1];
 
     const v2 = vx * vx + vy * vy;
-    const t = v2 < 1e-6 ? 1e9 : -((rx * vx + ry * vy) / v2);
+    if (v2 < 1e-6) {
+        // Relative velocity is essentially zero so the separation remains
+        // constant.  Return an infinite time and the current distance to avoid
+        // propagating huge values.
+        return { time: Infinity, dist: Math.hypot(rx, ry) };
+    }
+
+    const t = -((rx * vx + ry * vy) / v2);
     const xCPA = rx + vx * t;
     const yCPA = ry + vy * t;
     const d = Math.hypot(xCPA, yCPA);


### PR DESCRIPTION
## Summary
- use `Infinity` when relative velocity is near zero in `computeCPA`
- update unit test expectation

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec95898cc8325aec0994a85ce0ca6