### PR TITLE
Fix track range clamping

### DIFF
--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -825,7 +825,8 @@ class Simulator {
     calculateAllData(track) {
         const dx = track.x - this.ownShip.x;
         const dy = track.y - this.ownShip.y;
-        track.range = Math.max(0, Math.min(359.9, Math.sqrt(dx**2 + dy**2)));
+        // Store the true distance between own ship and the track
+        track.range = Math.sqrt(dx ** 2 + dy ** 2);
         track.bearing = (this.toDegrees(Math.atan2(dx, dy)) + 360) % 360;
 
         const ownShipCanvasAngle = this.toRadians(this.bearingToCanvasAngle(this.ownShip.course));


### PR DESCRIPTION
## Summary
- let `track.range` store real distance instead of being capped

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec95706f48325a6a692b161897c68