### PR TITLE
Add ORCA wrapper

### DIFF
--- a/src/types/rvo2.d.ts
+++ b/src/types/rvo2.d.ts
@@ -1,0 +1,1 @@
+declare module 'rvo2';


### PR DESCRIPTION
## Summary
- implement an ORCA-based wrapper around the `rvo2` library
- provide a module declaration stub for `rvo2`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed2bd22988325b3e8b4aa4d9ad3ee