### PR TITLE
Add TrafficSim implementation

### DIFF
--- a/src/traffic/TrafficSim.ts
+++ b/src/traffic/TrafficSim.ts
@@ -1,16 +1,151 @@
 import { OrcaWrapper } from './OrcaWrapper.js';
-import { applyColregsBias, BiasSettings } from './ColregsBias.js';
+import {
+  classifyEncounter,
+  legalPreferredVelocity,
+  Encounter,
+} from './ColregsBias.js';
+
+export interface TrafficSimArgs {
+  laneWidthNm: number;
+  timeStep: number;
+  timeHorizon: number;
+  neighborDist: number;
+  radius: number;
+  maxSpeed: number;
+  turnRateRad: number;
+}
+
+interface Track {
+  id: string;
+  posXY: [number, number];
+  velXY: [number, number];
+  waypoints: [number, number][];
+  encounter?: Encounter;
+  wpIndex: number;
+  speed: number; // meters per second
+}
+
+const M_PER_NM = 1852;
+const DEG_PER_M = 1 / (60 * M_PER_NM);
 
 export class TrafficSim {
   private wrapper: OrcaWrapper;
+  private tracks = new Map<string, Track>();
+  private readonly timeStep: number;
+  private readonly turnRateRad: number;
 
-  constructor(id: string, private bias: BiasSettings) {
-    this.wrapper = new OrcaWrapper(id);
+  constructor(private args: TrafficSimArgs) {
+    this.wrapper = new OrcaWrapper(
+      args.timeStep,
+      args.timeHorizon,
+      args.neighborDist,
+      args.radius,
+      args.maxSpeed
+    );
+    this.timeStep = args.timeStep;
+    this.turnRateRad = args.turnRateRad;
   }
 
-  step(dt: number, speed: number): void {
-    const adjustedSpeed = applyColregsBias(speed, this.bias);
-    console.log(`Advancing sim with speed ${adjustedSpeed}`);
-    this.wrapper.simulateStep(dt);
+  addTrack(
+    id: string,
+    startPos: [number, number],
+    waypoints: [number, number][],
+    speedMps: number
+  ): void {
+    const wp = waypoints[0] ?? startPos;
+    const heading = Math.atan2(wp[1] - startPos[1], wp[0] - startPos[0]);
+    const vel: [number, number] = [
+      Math.cos(heading) * speedMps,
+      Math.sin(heading) * speedMps,
+    ];
+    const track: Track = {
+      id,
+      posXY: [...startPos],
+      velXY: vel,
+      waypoints: [...waypoints],
+      wpIndex: 0,
+      speed: speedMps,
+    };
+    this.tracks.set(id, track);
+    this.wrapper.addAgent(id, track.posXY, track.velXY);
+  }
+
+  private relativeBearing(from: Track, to: Track): number {
+    const dx = to.posXY[0] - from.posXY[0];
+    const dy = to.posXY[1] - from.posXY[1];
+    const brg = Math.atan2(dy, dx);
+    const hdg = Math.atan2(from.velXY[1], from.velXY[0]);
+    const rel = ((brg - hdg) * 180) / Math.PI;
+    return (rel + 360) % 360;
+  }
+
+  private preferredToWaypoint(t: Track): [number, number] {
+    const wp = t.waypoints[t.wpIndex];
+    if (!wp) return t.velXY;
+    const dx = wp[0] - t.posXY[0];
+    const dy = wp[1] - t.posXY[1];
+    const dist = Math.hypot(dx, dy);
+    if (dist < t.speed * this.timeStep) {
+      if (t.wpIndex < t.waypoints.length - 1) {
+        t.wpIndex += 1;
+      }
+    }
+    const heading = Math.atan2(dy, dx);
+    return [Math.cos(heading) * t.speed, Math.sin(heading) * t.speed];
+  }
+
+  tick(): void {
+    const list = Array.from(this.tracks.values());
+    // classify encounters
+    for (let i = 0; i < list.length; i++) {
+      const a = list[i];
+      for (let j = i + 1; j < list.length; j++) {
+        const b = list[j];
+        const encA = classifyEncounter(this.relativeBearing(a, b));
+        const encB = classifyEncounter(this.relativeBearing(b, a));
+        a.encounter = encA;
+        b.encounter = encB;
+      }
+    }
+
+    // set preferred velocities
+    for (const t of list) {
+      const pref = this.preferredToWaypoint(t);
+      const vPref = legalPreferredVelocity(
+        t.encounter ?? 'none',
+        pref,
+        this.turnRateRad
+      );
+      this.wrapper.setAgentState(t.id, t.posXY, t.velXY);
+      this.wrapper.setPreferredVelocity(t.id, vPref);
+    }
+
+    this.wrapper.step();
+
+    // update positions
+    for (const t of list) {
+      t.velXY = this.wrapper.getVelocity(t.id);
+      t.posXY = [
+        t.posXY[0] + t.velXY[0] * this.timeStep,
+        t.posXY[1] + t.velXY[1] * this.timeStep,
+      ];
+    }
+  }
+
+  getSnapshot(): { id: string; posLatLon: [number, number]; cog: number; sog: number }[] {
+    const result = [] as {
+      id: string;
+      posLatLon: [number, number];
+      cog: number;
+      sog: number;
+    }[];
+    for (const t of this.tracks.values()) {
+      const lat = t.posXY[1] * DEG_PER_M;
+      const lon = t.posXY[0] * DEG_PER_M;
+      const cog = (Math.atan2(t.velXY[1], t.velXY[0]) * 180) / Math.PI;
+      const sog = Math.hypot(t.velXY[0], t.velXY[1]);
+      result.push({ id: t.id, posLatLon: [lat, lon], cog, sog });
+    }
+    return result;
   }
 }


### PR DESCRIPTION
## Summary
- implement `TrafficSim` class for ORCA‐based simulation

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc --noEmit` *(fails: cannot find React typings)*

------
https://chatgpt.com/codex/tasks/task_e_686ed76fba18832583a701cd97db4d48