### PR TITLE
Add stress test for traffic simulation

### DIFF
--- a/tests/trafficStress.test.ts
+++ b/tests/trafficStress.test.ts
@@ -1,0 +1,10 @@
+import buildScenario from '../src/traffic/buildScenario'
+import TrafficSim from '../src/traffic/TrafficSim'
+
+test('20+ mobile ships never breach 0.25 NM CPA in 10 min sim', () => {
+  const sim = new TrafficSim(buildScenario())
+  const steps = 10 * 60 / 0.25  // 10 min @ 0.25 s
+  for (let i = 0; i < steps; i++) sim.tick()
+  const logs = sim.getEncounterLog()
+  expect(logs.every(e => e.cpaMeters >= 463)).toBe(true)
+})


### PR DESCRIPTION
## Summary
- add a stress test that checks for CPA violations under heavy traffic

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0bada2888325b008d6f4c7db8a2c