### PR TITLE
Add static collision test

### DIFF
--- a/tests/trafficStress.test.ts
+++ b/tests/trafficStress.test.ts
@@ -1,10 +1,27 @@
-import buildScenario from '../src/traffic/buildScenario'
-import TrafficSim from '../src/traffic/TrafficSim'
+import buildScenario, { ScenarioConfig } from '../src/traffic/buildScenario'
+import TrafficSim, { DEFAULT_ARGS } from '../src/traffic/TrafficSim'
 
 test('20+ mobile ships never breach 0.25 NM CPA in 10 min sim', () => {
-  const sim = new TrafficSim(buildScenario())
-  const steps = 10 * 60 / 0.25  // 10 min @ 0.25 s
+  const sim = new TrafficSim(DEFAULT_ARGS, buildScenario())
+  const steps = 10 * 60 / DEFAULT_ARGS.timeStep  // 10 min
   for (let i = 0; i < steps; i++) sim.tick()
   const logs = sim.getEncounterLog()
   expect(logs.every(e => e.cpaMeters >= 463)).toBe(true)
+})
+
+test('no static collision', () => {
+  const scenario: ScenarioConfig = {
+    mobiles: [
+      { id: 'M1', start: [-2000, 0], waypoints: [[2000, 0]], speedMps: 5 }
+    ],
+    statics: [
+      { id: 'S1', pos: [0, 0], radius: 200 }
+    ]
+  }
+  const sim = new TrafficSim(DEFAULT_ARGS, scenario)
+  const steps = 10 * 60 / DEFAULT_ARGS.timeStep
+  for (let i = 0; i < steps; i++) sim.tick()
+  const logs = sim.getEncounterLog()
+  const entry = logs.find(l => l.ids.includes('M1') && l.ids.includes('S1'))
+  expect(entry && entry.cpaMeters >= 463).toBe(true)
 })


### PR DESCRIPTION
## Summary
- log closest point of approach between agents and obstacles
- support constructing `TrafficSim` from just a scenario
- expose default ORCA sim args
- test that traffic keeps 0.25NM separation from statics

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0c9903488325bc97397561b53e41