### PR TITLE
Add traffic profiling script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "vitest"
+    "test": "vitest",
+    "profile": "tsx scripts/profile.ts"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/scripts/profile.ts
+++ b/scripts/profile.ts
@@ -1,0 +1,21 @@
+import { performance } from 'node:perf_hooks'
+import TrafficSim, { DEFAULT_ARGS } from '../src/traffic/TrafficSim'
+import buildScenario from '../src/traffic/buildScenario'
+
+const scenario = buildScenario()
+const sim = new TrafficSim(DEFAULT_ARGS, scenario)
+const steps = Math.round(60 / DEFAULT_ARGS.timeStep)
+let maxMs = 0
+console.time('sim')
+const start = performance.now()
+for (let i = 0; i < steps; i++) {
+  const frameStart = performance.now()
+  sim.tick()
+  const elapsed = performance.now() - frameStart
+  if (elapsed > maxMs) maxMs = elapsed
+}
+const total = performance.now() - start
+console.timeEnd('sim')
+console.log('avg frame ms', (total / steps).toFixed(3))
+console.log('max frame ms', maxMs.toFixed(3))
+console.log('#agents processed', scenario.mobiles.length + scenario.statics.length)


### PR DESCRIPTION
## Summary
- add a performance profiling helper under `scripts/profile.ts`
- expose npm script `profile` to run the profiler

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f16ee8f608325b4ce10846cf18405