### PR TITLE
Add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ When viewed on mobile, rotate to landscape orientation for the best experience. 
 ## Simulator notes
 
 - ORCA max neighbors are set to 15 and neighbor distances refreshed before each simulation step. For scenarios with more than 50 agents, switch to sector-pruning (TODO).
+
+[![traffic-sim-ci](https://github.com/<USER>/<REPO>/actions/workflows/traffic.yml/badge.svg)](https://github.com/<USER>/<REPO>/actions/workflows/traffic.yml)


### PR DESCRIPTION
## Summary
- add placeholder for traffic sim CI badge in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1a540f0883259f27a7b5d9544e18