### PR TITLE
Fix rewind time logic

### DIFF
--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -607,7 +607,12 @@ class Simulator {
         this.updatePhysics(deltaTime);
 
         if (this.isSimulationRunning) {
-            this.simulationElapsed += (deltaTime / 1000) * Math.abs(this.simulationSpeed);
+            const dt = (deltaTime / 1000) * Math.abs(this.simulationSpeed);
+            if (this.simulationSpeed >= 0) {
+                this.simulationElapsed += dt;
+            } else {
+                this.simulationElapsed = Math.max(0, this.simulationElapsed - dt);
+            }
             this.sceneDirty = true;
         }
 


### PR DESCRIPTION
## Summary
- account for negative speed in game loop

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687009ab9a0c8325bb8c68e553969a7d