### PR TITLE
Implement COLREGS bias utilities

### DIFF
--- a/src/traffic/ColregsBias.ts
+++ b/src/traffic/ColregsBias.ts
@@ -1,9 +1,33 @@
 export interface BiasSettings {
+  /**
+   * How strongly to bias toward the legally preferred maneuver.
+   * A value of 0 returns the original velocity while 1 applies the
+   * full COLREGS turn or speed reduction.
+   */
   aggressiveness: number;
 }
 
-export function applyColregsBias(speed: number, bias: BiasSettings): number {
-  return speed * (1 - bias.aggressiveness);
+/**
+ * Blend the current desired velocity with the maneuver required by COLREGS.
+ *
+ * @param enc          Encounter classification relative to the other vessel.
+ * @param curVel       Current desired velocity vector in meters per second.
+ * @param turnRateRad  Maximum permitted turn rate in radians.
+ * @param bias         Aggressiveness of the maneuver from 0 to 1.
+ * @returns Adjusted velocity respecting COLREGS.
+ */
+export function applyColregsBias(
+  enc: Encounter,
+  curVel: [number, number],
+  turnRateRad: number,
+  bias: BiasSettings
+): [number, number] {
+  const legal = legalPreferredVelocity(enc, curVel, turnRateRad);
+  const a = Math.min(Math.max(bias.aggressiveness, 0), 1);
+  return [
+    curVel[0] * (1 - a) + legal[0] * a,
+    curVel[1] * (1 - a) + legal[1] * a,
+  ];
 }
 
 export type Encounter =

--- a/tests/colregsBias.test.ts
+++ b/tests/colregsBias.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from 'vitest'
+import {
+  classifyEncounter,
+  legalPreferredVelocity,
+  applyColregsBias,
+  BiasSettings,
+  Encounter
+} from '../src/traffic/ColregsBias'
+
+describe('classifyEncounter', () => {
+  test('returns correct sector names', () => {
+    expect(classifyEncounter(0)).toBe('headOn')
+    expect(classifyEncounter(90)).toBe('crossingStarboard')
+    expect(classifyEncounter(180)).toBe('headOn')
+    expect(classifyEncounter(270)).toBe('crossingPort')
+    expect(classifyEncounter(150)).toBe('overtaking')
+  })
+})
+
+describe('applyColregsBias', () => {
+  const vel: [number, number] = [10, 0]
+  const rate = Math.PI / 2 // 90 deg turn
+  const bias: BiasSettings = { aggressiveness: 0.5 }
+
+  test('blends current velocity with legal maneuver', () => {
+    const enc: Encounter = 'crossingStarboard'
+    const out = applyColregsBias(enc, vel, rate, bias)
+    const legal = legalPreferredVelocity(enc, vel, rate)
+    expect(out[0]).toBeCloseTo(vel[0] * 0.5 + legal[0] * 0.5)
+    expect(out[1]).toBeCloseTo(vel[1] * 0.5 + legal[1] * 0.5)
+  })
+
+  test('aggressiveness 0 returns original velocity', () => {
+    const out = applyColregsBias('overtaking', vel, rate, { aggressiveness: 0 })
+    expect(out[0]).toBeCloseTo(vel[0])
+    expect(out[1]).toBeCloseTo(vel[1])
+  })
+
+  test('aggressiveness 1 returns legal velocity', () => {
+    const enc: Encounter = 'crossingPort'
+    const out = applyColregsBias(enc, vel, rate, { aggressiveness: 1 })
+    const legal = legalPreferredVelocity(enc, vel, rate)
+    expect(out[0]).toBeCloseTo(legal[0])
+    expect(out[1]).toBeCloseTo(legal[1])
+  })
+})


### PR DESCRIPTION
## Summary
- implement blending logic for applyColregsBias
- document bias settings and new function
- add unit tests for encounter classification and bias blending

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727acc0c98832588645045b086de79