### PR TITLE
Add rvo2 package and docs on installing deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ When viewed on mobile, rotate to landscape orientation for the best experience. 
 - ORCA max neighbors are set to 15 and neighbor distances refreshed before each simulation step. For scenarios with more than 50 agents, switch to sector-pruning (TODO).
 
 [![traffic-sim-ci](https://github.com/<USER>/<REPO>/actions/workflows/traffic.yml/badge.svg)](https://github.com/<USER>/<REPO>/actions/workflows/traffic.yml)
+
+## Running Tests
+
+Before running the unit tests, install dependencies with:
+
+```bash
+npm install
+```
+
+Then execute the test suite using `npm test`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "rvo2": "^0.0.0"
   },
   "devDependencies": {
     "typescript": "^5.2.0",


### PR DESCRIPTION
## Summary
- add `rvo2` to dependencies
- document installing deps before running `npm test`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687281b7265483259c9c17d11a5de727