### PR TITLE
Fix head-on detection near 0/360 degrees

### DIFF
--- a/src/traffic/ColregsBias.ts
+++ b/src/traffic/ColregsBias.ts
@@ -47,10 +47,9 @@ export type Encounter =
 export function classifyEncounter(bearingDeg: number): Encounter {
   // normalize bearing to range [0, 360)
   const beta = ((bearingDeg % 360) + 360) % 360;
-  const abs = Math.abs;
 
   // check head-on condition first
-  if (abs(beta) <= 5 || abs(beta - 180) <= 5) {
+  if (beta <= 5 || beta >= 355 || Math.abs(beta - 180) <= 5) {
     return 'headOn';
   }
 

--- a/tests/colregsBias.test.ts
+++ b/tests/colregsBias.test.ts
@@ -15,6 +15,11 @@ describe('classifyEncounter', () => {
     expect(classifyEncounter(270)).toBe('crossingPort')
     expect(classifyEncounter(150)).toBe('overtaking')
   })
+
+  test('bearings near 360° are headOn', () => {
+    expect(classifyEncounter(355)).toBe('headOn')
+    expect(classifyEncounter(-5)).toBe('headOn')
+  })
 })
 
 describe('applyColregsBias', () => {


### PR DESCRIPTION
## Summary
- update encounter classification to detect bearings within 5° of 0/360
- ensure negative bearings like -5° classify as head-on
- test classification for bearings near 355° and -5°

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687281b3edf88325a928b3aae215f8f8