### PR TITLE
Improve README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,12 @@ Before running the unit tests, install dependencies with:
 npm install
 ```
 
-Then execute the test suite using `npm test`.
+The install step pulls in all dependencies including `rvo2` and `vitest`.
+After installation, run the test suite with:
+
+```bash
+npm test
+```
+
+Continuous integration runs `npm ci` followed by `npm test`, so the same
+dependencies are installed in CI.


### PR DESCRIPTION
## Summary
- clarify that `npm install` is required to fetch dependencies like `rvo2` and `vitest`
- explain that CI performs `npm ci` before running `npm test`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68728527b1d08325a13a9f0e7c967e43