### PR TITLE
Fix YAML workflow syntax

### DIFF
--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: ${{ matrix.node }} }
+        with:
+          node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm test -- --runInBand
       - run: npm run profile


### PR DESCRIPTION
## Summary
- fix workflow YAML to use multi-line `with:` block

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872865eacb88325ba5a2ee833964f6c