### PR TITLE
Improve head-on detection

### DIFF
--- a/src/traffic/ColregsBias.ts
+++ b/src/traffic/ColregsBias.ts
@@ -44,12 +44,25 @@ export type Encounter =
  *                   Any numeric input is accepted and normalized to 0-360.
  * @returns The encounter classification.
  */
-export function classifyEncounter(bearingDeg: number): Encounter {
+export function classifyEncounter(
+  bearingDeg: number,
+  otherHeadingDeg?: number
+): Encounter {
   // normalize bearing to range [0, 360)
   const beta = ((bearingDeg % 360) + 360) % 360;
 
+  // check whether headings are roughly reciprocal when provided
+  let reciprocal = true;
+  if (otherHeadingDeg !== undefined) {
+    const rel = ((otherHeadingDeg % 360) + 360) % 360;
+    reciprocal = Math.abs(rel - 180) <= 10;
+  }
+
   // check head-on condition first
-  if (beta <= 5 || beta >= 355 || Math.abs(beta - 180) <= 5) {
+  if (
+    reciprocal &&
+    (beta <= 5 || beta >= 355 || Math.abs(beta - 180) <= 5)
+  ) {
     return 'headOn';
   }
 

--- a/src/traffic/TrafficSim.ts
+++ b/src/traffic/TrafficSim.ts
@@ -112,6 +112,10 @@ export class TrafficSim {
     return (rel + 360) % 360;
   }
 
+  private headingDeg(t: Track): number {
+    return (Math.atan2(t.velXY[1], t.velXY[0]) * 180) / Math.PI;
+  }
+
   private preferredToWaypoint(t: Track): [number, number] {
     const wp = t.waypoints[t.wpIndex];
     if (!wp) return t.velXY;
@@ -146,8 +150,16 @@ export class TrafficSim {
       const a = list[i];
       for (let j = i + 1; j < list.length; j++) {
         const b = list[j];
-        const encA = classifyEncounter(this.relativeBearing(a, b));
-        const encB = classifyEncounter(this.relativeBearing(b, a));
+        const relHdgAB = this.headingDeg(b) - this.headingDeg(a);
+        const relHdgBA = this.headingDeg(a) - this.headingDeg(b);
+        const encA = classifyEncounter(
+          this.relativeBearing(a, b),
+          (relHdgAB + 360) % 360
+        );
+        const encB = classifyEncounter(
+          this.relativeBearing(b, a),
+          (relHdgBA + 360) % 360
+        );
         a.encounter = select(a.encounter!, encA);
         b.encounter = select(b.encounter!, encB);
       }

--- a/tests/colregsBias.test.ts
+++ b/tests/colregsBias.test.ts
@@ -20,6 +20,11 @@ describe('classifyEncounter', () => {
     expect(classifyEncounter(355)).toBe('headOn')
     expect(classifyEncounter(-5)).toBe('headOn')
   })
+
+  test('same-heading vessels are not headOn', () => {
+    expect(classifyEncounter(0, 0)).not.toBe('headOn')
+    expect(classifyEncounter(180, 0)).not.toBe('headOn')
+  })
 })
 
 describe('applyColregsBias', () => {

--- a/tests/headOnCpa.test.ts
+++ b/tests/headOnCpa.test.ts
@@ -17,3 +17,14 @@ test('head-on encounter keeps CPA above 0.25 NM', () => {
   const entry = logs.find(l => l.ids.includes('A') && l.ids.includes('B'))
   expect(entry && entry.cpaMeters >= 463).toBe(true)
 })
+
+test('same-direction vessels are not head-on', () => {
+  const sim = new TrafficSim(DEFAULT_ARGS)
+  sim.addTrack('A', [-1000, 0], [[1000, 0]], 5)
+  sim.addTrack('B', [-1500, 0], [[500, 0]], 5)
+
+  sim.tick()
+  const tracks = (sim as any).tracks
+  expect(tracks.get('A').encounter).not.toBe('headOn')
+  expect(tracks.get('B').encounter).not.toBe('headOn')
+})


### PR DESCRIPTION
## Summary
- classify encounters using relative heading
- compute heading difference in TrafficSim
- test that same-heading vessels aren't flagged head-on

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a978d8588325ae8526d1380ebacf