### PR TITLE
Handle port crossing in arena simulator

### DIFF
--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -219,10 +219,22 @@ class ContactController {
             const rel=(this.t.threat&&this._relativeSituation(this.t,this.t.threat))||'UNKNOWN';
             let deltaCrs=0, deltaSpd=0;
             switch(rel){
-                case 'HEAD_ON': deltaCrs=30; break;
-                case 'CROSS_GIVEWAY': deltaCrs=35; break;
-                case 'OVERTAKING': deltaCrs=0; deltaSpd=-0.4*this.t.speed; break;
-                default: deltaCrs=25;
+                case 'HEAD_ON':
+                    deltaCrs = 30;
+                    break;
+                case 'CROSS_GIVEWAY':
+                    deltaCrs = 35;
+                    break;
+                case 'OVERTAKING':
+                    deltaCrs = 0;
+                    deltaSpd = -0.4 * this.t.speed;
+                    break;
+                case 'CROSS_STANDON':
+                    deltaCrs = 0;
+                    deltaSpd = 0;
+                    break;
+                default:
+                    deltaCrs = 25;
             }
             this.t._targetCourse=(this.t.course+deltaCrs+360)%360;
             this.t._targetSpeed=Math.max(2,this.t.speed+deltaSpd);
@@ -252,6 +264,7 @@ class ContactController {
         const relBrg=(brg - a.course + 360)%360;
         if(relBrg>112.5&&relBrg<247.5) return 'OVERTAKING';
         if(relBrg>0&&relBrg<112.5) return 'CROSS_GIVEWAY';
+        if(relBrg>=247.5) return 'CROSS_STANDON';
         return 'OTHER';
     }
     _asParticle(v){const rad=(90-v.course)*Math.PI/180;return{x:v.x,y:v.y,vx:v.speed*Math.cos(rad),vy:v.speed*Math.sin(rad)}}

--- a/tests/colregsBias.test.ts
+++ b/tests/colregsBias.test.ts
@@ -20,6 +20,11 @@ describe('classifyEncounter', () => {
     expect(classifyEncounter(355)).toBe('headOn')
     expect(classifyEncounter(-5)).toBe('headOn')
   })
+
+  test('port crossing is not mistaken for overtaking', () => {
+    expect(classifyEncounter(250)).toBe('crossingPort')
+    expect(classifyEncounter(300)).toBe('crossingPort')
+  })
 })
 
 describe('applyColregsBias', () => {

--- a/tests/relativeSituation.test.ts
+++ b/tests/relativeSituation.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from 'vitest'
+
+function relativeSituation(a: {x:number,y:number,course:number}, b:{x:number,y:number,course:number}){
+  const brg=(Math.atan2(b.y-a.y,b.x-a.x)*180/Math.PI+360)%360;
+  const diffHdgs=Math.abs(((a.course - b.course + 540)%360)-180);
+  if(diffHdgs>150&&diffHdgs<210) return 'HEAD_ON';
+  const relBrg=(brg - a.course + 360)%360;
+  if(relBrg>112.5&&relBrg<247.5) return 'OVERTAKING';
+  if(relBrg>0&&relBrg<112.5) return 'CROSS_GIVEWAY';
+  if(relBrg>=247.5) return 'CROSS_STANDON';
+  return 'OTHER';
+}
+
+test('port crossing returns CROSS_STANDON',()=>{
+  const own={x:0,y:0,course:0};
+  const tgt={x:-1,y:0.5,course:90};
+  expect(relativeSituation(own,tgt)).toBe('CROSS_STANDON');
+})


### PR DESCRIPTION
## Summary
- detect port side crossing in `arena.js`
- maintain course when stand-on for a port crossing
- cover new CROSS_STANDON case in tests
- add regression tests to ensure port crossings aren't marked overtaking

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a9777fc88325af143134b3b189aa