### PR TITLE
Fix relative bearing and add crossing tests

### DIFF
--- a/src/traffic/TrafficSim.ts
+++ b/src/traffic/TrafficSim.ts
@@ -103,13 +103,17 @@ export class TrafficSim {
     this.wrapper.addAgent(id, track.posXY, track.velXY);
   }
 
+  /**
+   * Bearing from `from` to `to` relative to `from`'s heading.
+   * Positive values indicate the target is on the starboard side.
+   */
   private relativeBearing(from: Track, to: Track): number {
     const dx = to.posXY[0] - from.posXY[0];
     const dy = to.posXY[1] - from.posXY[1];
     const brg = Math.atan2(dy, dx);
     const hdg = Math.atan2(from.velXY[1], from.velXY[0]);
-    const rel = ((brg - hdg) * 180) / Math.PI;
-    return (rel + 360) % 360;
+    const rel = ((hdg - brg) * 180) / Math.PI;
+    return (rel % 360 + 360) % 360;
   }
 
   private preferredToWaypoint(t: Track): [number, number] {

--- a/tests/crossingClassification.test.ts
+++ b/tests/crossingClassification.test.ts
@@ -1,0 +1,31 @@
+import TrafficSim, { DEFAULT_ARGS } from '../src/traffic/TrafficSim'
+
+/** Verify starboard crossing classification */
+test('starboard crossing encounter is detected', () => {
+  const sim = new TrafficSim(DEFAULT_ARGS)
+  // A heading east
+  sim.addTrack('A', [-1000, 0], [[1000, 0]], 5)
+  // B approaches from starboard heading north
+  sim.addTrack('B', [0, -1000], [[0, 1000]], 5)
+
+  sim.tick()
+
+  const tracks = (sim as any).tracks
+  expect(tracks.get('A').encounter).toBe('crossingStarboard')
+  expect(tracks.get('B').encounter).toBe('crossingPort')
+})
+
+/** Verify port crossing classification */
+test('port crossing encounter is detected', () => {
+  const sim = new TrafficSim(DEFAULT_ARGS)
+  // A heading east
+  sim.addTrack('A', [-1000, 0], [[1000, 0]], 5)
+  // C approaches from port heading south
+  sim.addTrack('C', [0, 1000], [[0, -1000]], 5)
+
+  sim.tick()
+
+  const tracks = (sim as any).tracks
+  expect(tracks.get('A').encounter).toBe('crossingPort')
+  expect(tracks.get('C').encounter).toBe('crossingStarboard')
+})

--- a/tests/multiEncounter.test.ts
+++ b/tests/multiEncounter.test.ts
@@ -11,5 +11,5 @@ test('highest priority encounter is kept when multiple ships present', () => {
   const tracks = (sim as any).tracks
   expect(tracks.get('A').encounter).toBe('headOn')
   expect(tracks.get('B').encounter).toBe('headOn')
-  expect(tracks.get('C').encounter).toBe('crossingStarboard')
+  expect(tracks.get('C').encounter).toBe('crossingPort')
 })


### PR DESCRIPTION
## Summary
- correct orientation of relative bearings used for encounter detection
- update encounter expectations accordingly
- add new unit tests for starboard and port crossing scenarios

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a9740b2c8325b204605eb5f20048