### PR TITLE
Fix GitHub Actions badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ When viewed on mobile, rotate to landscape orientation for the best experience. 
 
 - ORCA max neighbors are set to 15 and neighbor distances refreshed before each simulation step. For scenarios with more than 50 agents, switch to sector-pruning (TODO).
 
-[![traffic-sim-ci](https://github.com/<USER>/<REPO>/actions/workflows/traffic.yml/badge.svg)](https://github.com/<USER>/<REPO>/actions/workflows/traffic.yml)
+[![traffic-sim-ci](https://github.com/matthewcla/Maneuver-Rejoice-/actions/workflows/traffic.yml/badge.svg)](https://github.com/matthewcla/Maneuver-Rejoice-/actions/workflows/traffic.yml)
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- replace `<USER>/<REPO>` placeholders with `matthewcla/Maneuver-Rejoice-`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6872afeeefb08325b0967ffc07c09ad0