### PR TITLE
Setup vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ npm test
 
 Continuous integration runs `npm ci` followed by `npm test`, so the same
 dependencies are installed in CI.
+
+Vitest is configured in `vite.config.ts` using global APIs and a Node
+environment. Type support for the tests lives in `tsconfig.vitest.json`.

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "tests"],
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,11 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'node',
+    includeSource: ['src/**/*.{ts,tsx}']
+  }
 });


### PR DESCRIPTION
## Summary
- configure Vitest in `vite.config.ts`
- add `tsconfig.vitest.json` for test type support
- document the Vitest setup in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872f7df09688325bc3ea67905238860